### PR TITLE
 Add DocuTrac vulns (CVE-2018-5551, 5552)

### DIFF
--- a/2018/5xxx/CVE-2018-5551.json
+++ b/2018/5xxx/CVE-2018-5551.json
@@ -1,18 +1,82 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-5551",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "cve@rapid7.com",
+      "ID": "CVE-2018-5551",
+      "STATE": "PUBLIC",
+      "TITLE": "DocuTrac DTISQLInstaller.exe Hard-Coded Credentials"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "DTISQLInstaller.exe",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<=",
+                                 "platform": "Windows",
+                                 "version_value": "1.6.4.0"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "DocuTrac"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Versions of DocuTrac QuicDoc and Office Therapy that ship with DTISQLInstaller.exe version 1.6.4.0 and prior contain three credentials with known passwords: QDMaster, OTMaster, and sa."
          }
       ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "HIGH",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "HIGH",
+         "baseScore": 9,
+         "baseSeverity": "CRITICAL",
+         "confidentialityImpact": "HIGH",
+         "integrityImpact": "HIGH",
+         "privilegesRequired": "NONE",
+         "scope": "CHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Hard-Coded Credentials (CWE-798)"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://blog.rapid7.com/2018/03/14/r7-2018-01-cve-2018-5551-cve-2018-5552-docutrac-office-therapy-installer-hard-coded-credentials-and-cryptographic-salt/"
+         }
+      ]
+   },
+   "source": {
+      "discovery": "EXTERNAL"
    }
 }

--- a/2018/5xxx/CVE-2018-5552.json
+++ b/2018/5xxx/CVE-2018-5552.json
@@ -1,18 +1,82 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2018-5552",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "cve@rapid7.com",
+      "ID": "CVE-2018-5552",
+      "STATE": "PUBLIC",
+      "TITLE": "DocuTrac DTISQLInstaller.exe Hard-Coded Salt"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "DTISQLInstaller.exe",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "affected": "<=",
+                                 "platform": "Windows",
+                                 "version_value": "1.6.4.0"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "DocuTrac"
+            }
+         ]
+      }
+   },
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "Versions of DocuTrac QuicDoc and Office Therapy that ship with DTISQLInstaller.exe version 1.6.4.0 and prior contains a hard-coded cryptographic salt, \"S@l+&pepper\"."
          }
       ]
+   },
+   "impact": {
+      "cvss": {
+         "attackComplexity": "HIGH",
+         "attackVector": "LOCAL",
+         "availabilityImpact": "NONE",
+         "baseScore": 2.9,
+         "baseSeverity": "LOW",
+         "confidentialityImpact": "LOW",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": " Use of a One-Way Hash with a Predictable Salt (CWE-760)"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "url": "https://blog.rapid7.com/2018/03/14/r7-2018-01-cve-2018-5551-cve-2018-5552-docutrac-office-therapy-installer-hard-coded-credentials-and-cryptographic-salt/"
+         }
+      ]
+   },
+   "source": {
+      "discovery": "EXTERNAL"
    }
 }


### PR DESCRIPTION
This is my first time using https://vulnogram.github.io , so hopefully the formatting of the new JSON fields all works out correctly.

This is also the first time we're PR'ing to the intermediary Rapid7 repo. The signature on d256f72 should survive the process if @shuckins-r7 lands this through the Github UI (assuming no changes -- if there are, I'll have to fix and merge through the cmd line to get the new signature).