### PR TITLE
Add 2019-5616, Circuitwerkes Sicon-8 RO vuln

### DIFF
--- a/2019/5xxx/CVE-2019-5616.json
+++ b/2019/5xxx/CVE-2019-5616.json
@@ -1,18 +1,113 @@
 {
-   "CVE_data_meta" : {
-      "ASSIGNER" : "cve@mitre.org",
-      "ID" : "CVE-2019-5616",
-      "STATE" : "RESERVED"
+   "CVE_data_meta": {
+      "ASSIGNER": "cve@rapid7.com",
+      "DATE_PUBLIC": "2019-03-12T15:00:00.000Z",
+      "ID": "CVE-2019-5616",
+      "STATE": "PUBLIC",
+      "TITLE": "CircuitWerkes Sicon-8 Client-Side Authentication Read-Only Bypass"
    },
-   "data_format" : "MITRE",
-   "data_type" : "CVE",
-   "data_version" : "4.0",
-   "description" : {
-      "description_data" : [
+   "affects": {
+      "vendor": {
+         "vendor_data": [
+            {
+               "product": {
+                  "product_data": [
+                     {
+                        "product_name": "Sicon-8",
+                        "version": {
+                           "version_data": [
+                              {
+                                 "version_name": "1.72",
+                                 "version_value": "1.72"
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               "vendor_name": "CircuitWerkes, Inc."
+            }
+         ]
+      }
+   },
+   "credit": [
+      {
+         "lang": "eng",
+         "value": "This issue was discovered and reported by independent researcher Ph055a, and was validated and disclosed by Rapid7's Coordinated Vulnerability Disclosure program."
+      }
+   ],
+   "data_format": "MITRE",
+   "data_type": "CVE",
+   "data_version": "4.0",
+   "description": {
+      "description_data": [
          {
-            "lang" : "eng",
-            "value" : "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem.  When the candidate has been publicized, the details for this candidate will be provided."
+            "lang": "eng",
+            "value": "CircuitWerkes Sicon-8, a hardware device used for managing electrical devices, ships with a web-based front-end controller and implements an authentication mechanism in JavaScript that is run in the context of a user's web browser."
          }
       ]
-   }
+   },
+   "exploit": [
+      {
+         "lang": "eng",
+         "value": "Because authentication is implemented as a JavaScript function that merely redirects the user away from the web app interface, rather than relying on session tokens or other more modern access controls, an attacker can navigate to http://address:port/index.htm using a standard web browser, and just before the page is fully rendered, hit the escape key to prevent the window.location redirect from executing. Once the page is rendered, the attacker can read all of the configured labels of a Sicon-8 device and retrieve the status of the labeled interfaces."
+      }
+   ],
+   "impact": {
+      "cvss": {
+         "attackComplexity": "LOW",
+         "attackVector": "NETWORK",
+         "availabilityImpact": "NONE",
+         "baseScore": 5.3,
+         "baseSeverity": "MEDIUM",
+         "confidentialityImpact": "LOW",
+         "integrityImpact": "NONE",
+         "privilegesRequired": "NONE",
+         "scope": "UNCHANGED",
+         "userInteraction": "NONE",
+         "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+         "version": "3.0"
+      }
+   },
+   "problemtype": {
+      "problemtype_data": [
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "CWE-603"
+               }
+            ]
+         },
+         {
+            "description": [
+               {
+                  "lang": "eng",
+                  "value": "Use of Client-Side Authentication"
+               }
+            ]
+         }
+      ]
+   },
+   "references": {
+      "reference_data": [
+         {
+            "name": "R7-2019-01: CircuitWerkes Sicon-8 Client-Side Authentication Read-Only Bypass (CVE-2019-5616)",
+            "refsource": "MISC",
+            "url": "https://blog.rapid7.com/2019/03/12/r7-2019-01-circuitwerkes-sicon-8-client-side-authentication-read-only-bypass-cve-2019-5616/"
+         }
+      ]
+   },
+   "source": {
+      "defect": [
+         "R7-2019-01"
+      ],
+      "discovery": "EXTERNAL"
+   },
+   "work_around": [
+      {
+         "lang": "eng",
+         "value": "Users of the Sicon-8 should not expose the web-based management console to untrusted networks."
+      }
+   ]
 }


### PR DESCRIPTION
This adds CVE-2019-5616, which was disclosed today at

https://blog.rapid7.com/2019/03/12/r7-2019-01-circuitwerkes-sicon-8-client-side-authentication-read-only-bypass-cve-2019-5616/
