### PR TITLE
Adding some CVEs for some old Metasploit vulns

### DIFF
--- a/2019/5xxx/CVE-2019-5618.json
+++ b/2019/5xxx/CVE-2019-5618.json
@@ -1,18 +1,81 @@
-{
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5618",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+ {
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Tod's Junk Converter 0.0.2"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2019-5618",
+    "ASSIGNER": "cve@rapid7.com",
+    "DATE_PUBLIC": "2010-08-17T00:00:00.000Z",
+    "TITLE": "A-PDF WAV to MP3 Stack-based Buffer Overflow",
+    "AKA": "",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "A-PDF",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "WAV to MP3",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "",
+                      "version_affected": "=",
+                      "version_value": "1.0.0",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121"
+          },
+          {
+            "lang": "eng",
+            "value": "Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "A-PDF WAV to MP3 version 1.0.0 suffers from an instance of CWE-121: Stack-based Buffer Overflow."
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "MISC",
+        "url": "https://www.rapid7.com/db/modules/exploit/windows/fileformat/a_pdf_wav_to_mp3",
+        "name": "https://www.rapid7.com/db/modules/exploit/windows/fileformat/a_pdf_wav_to_mp3"
+      }
+    ]
+  },
+  "exploit": [
+    {
+      "lang": "eng",
+      "value": "https://www.rapid7.com/db/modules/exploit/windows/fileformat/a_pdf_wav_to_mp3"
+    }
+  ]
 }

--- a/2019/5xxx/CVE-2019-5619.json
+++ b/2019/5xxx/CVE-2019-5619.json
@@ -1,18 +1,81 @@
-{
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5619",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+ {
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Tod's Junk Converter 0.0.2"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2019-5619",
+    "ASSIGNER": "cve@rapid7.com",
+    "DATE_PUBLIC": "2010-10-12T00:00:00.000Z",
+    "TITLE": "AASync.com AASync Stack-based Buffer Overflow",
+    "AKA": "",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "AASync.com",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "AASync",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "",
+                      "version_affected": "=",
+                      "version_value": "2.2.1.0",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121"
+          },
+          {
+            "lang": "eng",
+            "value": "Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "AASync.com AASync version 2.2.1.0 suffers from an instance of CWE-121: Stack-based Buffer Overflow."
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "MISC",
+        "url": "https://www.rapid7.com/db/modules/exploit/windows/ftp/aasync_list_reply",
+        "name": "https://www.rapid7.com/db/modules/exploit/windows/ftp/aasync_list_reply"
+      }
+    ]
+  },
+  "exploit": [
+    {
+      "lang": "eng",
+      "value": "https://www.rapid7.com/db/modules/exploit/windows/ftp/aasync_list_reply"
+    }
+  ]
 }

--- a/2019/5xxx/CVE-2019-5620.json
+++ b/2019/5xxx/CVE-2019-5620.json
@@ -1,18 +1,81 @@
-{
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5620",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+ {
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Tod's Junk Converter 0.0.2"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2019-5620",
+    "ASSIGNER": "cve@rapid7.com",
+    "DATE_PUBLIC": "2013-04-05T00:00:00.000Z",
+    "TITLE": "ABB MicroSCADA Pro SYS600 Missing Authentication for Critical Function",
+    "AKA": "",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "ABB",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "MicroSCADA Pro SYS600",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "",
+                      "version_affected": "=",
+                      "version_value": "9.3",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-306"
+          },
+          {
+            "lang": "eng",
+            "value": "Missing Authentication for Critical Function"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "ABB MicroSCADA Pro SYS600 version 9.3 suffers from an instance of CWE-306: Missing Authentication for Critical Function."
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "MISC",
+        "url": "https://www.rapid7.com/db/modules/exploit/windows/scada/abb_wserver_exec",
+        "name": "https://www.rapid7.com/db/modules/exploit/windows/scada/abb_wserver_exec"
+      }
+    ]
+  },
+  "exploit": [
+    {
+      "lang": "eng",
+      "value": "https://www.rapid7.com/db/modules/exploit/windows/scada/abb_wserver_exec"
+    }
+  ]
 }

--- a/2019/5xxx/CVE-2019-5621.json
+++ b/2019/5xxx/CVE-2019-5621.json
@@ -1,18 +1,81 @@
-{
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5621",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+ {
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Tod's Junk Converter 0.0.2"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2019-5621",
+    "ASSIGNER": "cve@rapid7.com",
+    "DATE_PUBLIC": "2013-06-30T00:00:00.000Z",
+    "TITLE": "ABBS Software Audio Media Player Stack-based Buffer Overflow",
+    "AKA": "",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "ABBS Software",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Audio Media Player",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "",
+                      "version_affected": "=",
+                      "version_value": "3.1",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-121"
+          },
+          {
+            "lang": "eng",
+            "value": "Stack-based Buffer Overflow"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "ABBS Software Audio Media Player version 3.1 suffers from an instance of CWE-121: Stack-based Buffer Overflow."
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "MISC",
+        "url": "https://www.rapid7.com/db/modules/exploit/windows/fileformat/abbs_amp_lst",
+        "name": "https://www.rapid7.com/db/modules/exploit/windows/fileformat/abbs_amp_lst"
+      }
+    ]
+  },
+  "exploit": [
+    {
+      "lang": "eng",
+      "value": "https://www.rapid7.com/db/modules/exploit/windows/fileformat/abbs_amp_lst"
+    }
+  ]
 }

--- a/2019/5xxx/CVE-2019-5622.json
+++ b/2019/5xxx/CVE-2019-5622.json
@@ -1,18 +1,81 @@
-{
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5622",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+ {
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Tod's Junk Converter 0.0.2"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2019-5622",
+    "ASSIGNER": "cve@rapid7.com",
+    "DATE_PUBLIC": "2011-03-11T00:00:00.000Z",
+    "TITLE": "Accellion File Transfer Appliance Use of Hard-coded Credentials",
+    "AKA": "",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Accellion",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "File Transfer Appliance",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "",
+                      "version_affected": "=",
+                      "version_value": "FTA_8_0_540",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-798"
+          },
+          {
+            "lang": "eng",
+            "value": "Use of Hard-coded Credentials"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Accellion File Transfer Appliance version FTA_8_0_540 suffers from an instance of CWE-798: Use of Hard-coded Credentials."
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "MISC",
+        "url": "https://www.rapid7.com/db/modules/exploit/linux/misc/accellion_fta_mpipe2",
+        "name": "https://www.rapid7.com/db/modules/exploit/linux/misc/accellion_fta_mpipe2"
+      }
+    ]
+  },
+  "exploit": [
+    {
+      "lang": "eng",
+      "value": "https://www.rapid7.com/db/modules/exploit/linux/misc/accellion_fta_mpipe2"
+    }
+  ]
 }

--- a/2019/5xxx/CVE-2019-5623.json
+++ b/2019/5xxx/CVE-2019-5623.json
@@ -1,18 +1,81 @@
-{
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5623",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
-    "data_type": "CVE",
-    "data_version": "4.0",
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+ {
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Tod's Junk Converter 0.0.2"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2019-5623",
+    "ASSIGNER": "cve@rapid7.com",
+    "DATE_PUBLIC": "2011-03-11T00:00:00.000Z",
+    "TITLE": "Accellion File Transfer Appliance Improper Neutralization of Special Elements used in a Command ('Command Injection')",
+    "AKA": "",
+    "STATE": "PUBLIC"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Accellion",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "File Transfer Appliance",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "",
+                      "version_affected": "=",
+                      "version_value": "FTA_8_0_540",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-77"
+          },
+          {
+            "lang": "eng",
+            "value": "Improper Neutralization of Special Elements used in a Command ('Command Injection')"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Accellion File Transfer Appliance version FTA_8_0_540 suffers from an instance of CWE-77: Improper Neutralization of Special Elements used in a Command ('Command Injection')."
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "MISC",
+        "url": "https://www.rapid7.com/db/modules/exploit/linux/misc/accellion_fta_mpipe2",
+        "name": "https://www.rapid7.com/db/modules/exploit/linux/misc/accellion_fta_mpipe2"
+      }
+    ]
+  },
+  "exploit": [
+    {
+      "lang": "eng",
+      "value": "https://www.rapid7.com/db/modules/exploit/linux/misc/accellion_fta_mpipe2"
+    }
+  ]
 }


### PR DESCRIPTION
So, take a look at these. They're semi-automatically generated CVEs for a handful of old vulnerabilities that have Metasploit modules, but no extant CVEs, and none of them affect CNA-maintained software.

No huge rush, I'm just trying to validate this approach. If you love 'em, merge 'em and I'll PR up to MITRE. If you feel strongly that we need a little more manual special sauce in the descriptions, I can do that too, but I'm shooting for a bare minimum here.

Once these are accepted by MITRE, I will PR the original modules with the CVE identifiers.