### PR TITLE
CVE-2019-5629 for IA

### DIFF
--- a/2019/5xxx/CVE-2019-5629.json
+++ b/2019/5xxx/CVE-2019-5629.json
@@ -1,9 +1,41 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2019-05-29T17:17:00.000Z",
         "ID": "CVE-2019-5629",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Insight Agent",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "2.6.3",
+                                            "version_value": "2.6.3"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Rapid7, Inc."
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered and reported by Florian Bogner, an independent researcher at Bee IT Security."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +43,56 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Rapid7 Insight Agent, version 2.6.3 and prior, suffers from a local privilege escalation due to an uncontrolled DLL search path. Specifically, when Insight Agent 2.6.3 and prior starts, the Python interpreter attempts to load python3.dll at \"C:\\DLLs\\python3.dll,\" which normally is writable by locally authenticated users. Because of this, a malicious local user could use Insight Agent's startup conditions to elevate to SYSTEM privileges. This issue was fixed in Rapid7 Insight Agent 2.6.4."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.7"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-427: Uncontrolled Search Path Element"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://help.rapid7.com/insightagent/release-notes/archive/2019/05/#20190529",
+                "refsource": "CONFIRM",
+                "url": "https://help.rapid7.com/insightagent/release-notes/archive/2019/05/#20190529"
+            },
+            {
+                "name": "https://bogner.sh/2019/06/local-privilege-escalation-in-rapid7s-windows-insight-idr-agent/",
+                "refsource": "MISC",
+                "url": "https://bogner.sh/2019/06/local-privilege-escalation-in-rapid7s-windows-insight-idr-agent/"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2019/5xxx/CVE-2019-5629.json
+++ b/2019/5xxx/CVE-2019-5629.json
@@ -25,7 +25,7 @@
                             }
                         ]
                     },
-                    "vendor_name": "Rapid7, Inc."
+                    "vendor_name": "Rapid7"
                 }
             ]
         }
@@ -33,7 +33,7 @@
     "credit": [
         {
             "lang": "eng",
-            "value": "This issue was discovered and reported by Florian Bogner, an independent researcher at Bee IT Security."
+            "value": "This issue was discovered, and reported to Rapid7, by independent researcher Florian Bogner at Bee IT Security. It is being disclosed in accordance with Rapid7's vulnerability disclosure policy (https://www.rapid7.com/disclosure/)."
         }
     ],
     "data_format": "MITRE",
@@ -92,7 +92,14 @@
             }
         ]
     },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "This issue affects Insight Agent instances at version 2.6.4 and older. Insight Agent will normally update automatically. Otherwise, if your Insight Agent instances are not running 2.6.5 or higher, ensure that you update all instances to 2.6.5 (or later if available)."
+        }
+    ],
     "source": {
+        "advisory": "R7-2019-19",
         "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
This adds a CVE for the recently disclosed Insight Agent local priv escalation issue. Can you take a look at this and kick it up to MITRE? I'm on vaca for the next week or so, so I might be super slow on that turn around. If there are any minor edits or anything, can you take 'em?

Thanks!

(Also, it's so weird to me that a local priv esc gets you a 7.8 on CVSS, but c'est la vie I guess.)