### PR TITLE
Add TwinCAT vulns

### DIFF
--- a/2019/5xxx/CVE-2019-5636.json
+++ b/2019/5xxx/CVE-2019-5636.json
@@ -38,7 +38,7 @@
                             }
                         ]
                     },
-                    "vendor_name": "Rapid7"
+                    "vendor_name": "Beckhoff"
                 }
             ]
         }

--- a/2019/5xxx/CVE-2019-5636.json
+++ b/2019/5xxx/CVE-2019-5636.json
@@ -1,9 +1,54 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2019-10-08T14:05:00.000Z",
         "ID": "CVE-2019-5636",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Beckhoff TwinCAT Discovery Service Denial of Service"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "TwinCAT 2",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "2304",
+                                            "version_value": "2304"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "product_name": "TwinCAT 3.1",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "4204.0",
+                                            "version_value": "4204.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Rapid7"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered, and reported to Rapid7, by Andreas Galauner at Rapid7. It is being disclosed in accordance with Rapid7's vulnerability disclosure policy (https://www.rapid7.com/disclosure/)."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +56,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "When a Beckhoff TwinCAT Runtime receives a malformed UDP packet, the ADS Discovery Service shuts down. Note that the TwinCAT devices are still performing as normal."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.8"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-404 Improper Resource Shutdown or Release"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://download.beckhoff.com/download/Document/product-security/Advisories/advisory-2019-004.pdf",
+                "refsource": "CONFIRM",
+                "url": "https://download.beckhoff.com/download/Document/product-security/Advisories/advisory-2019-004.pdf"
+            },
+            {
+                "name": "https://blog.rapid7.com/2019/10/08/r7-2019-32-denial-of-service-vulnerabilities-in-beckhoff-twincat-plc-environment-fixed/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2019/10/08/r7-2019-32-denial-of-service-vulnerabilities-in-beckhoff-twincat-plc-environment-fixed/"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "R7-2019-32",
+        "discovery": "EXTERNAL"
     }
 }

--- a/2019/5xxx/CVE-2019-5637.json
+++ b/2019/5xxx/CVE-2019-5637.json
@@ -38,7 +38,7 @@
                             }
                         ]
                     },
-                    "vendor_name": "Rapid7"
+                    "vendor_name": "Beckhoff"
                 }
             ]
         }

--- a/2019/5xxx/CVE-2019-5637.json
+++ b/2019/5xxx/CVE-2019-5637.json
@@ -1,9 +1,54 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2019-10-08T14:05:00.000Z",
         "ID": "CVE-2019-5637",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Beckhoff TwinCAT Profinet Driver Divide-by-Zero Denial of Service"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "TwinCAT 2",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "2304",
+                                            "version_value": "2304"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "product_name": "TwinCAT 3.1",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "4204.0",
+                                            "version_value": "4204.0"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Rapid7"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered, and reported to Rapid7, by Andreas Galauner at Rapid7. It is being disclosed in accordance with Rapid7's vulnerability disclosure policy (https://www.rapid7.com/disclosure/)."
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +56,57 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "When Beckhoff TwinCAT is configured to use the Profinet driver, a denial of service of the controller could be reached by sending a malformed UDP packet to the device."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.8"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-369 Divide By Zero"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://download.beckhoff.com/download/Document/product-security/Advisories/advisory-2019-007.pdf",
+                "refsource": "CONFIRM",
+                "url": "https://download.beckhoff.com/download/Document/product-security/Advisories/advisory-2019-007.pdf"
+            },
+            {
+                "name": "https://blog.rapid7.com/2019/10/08/r7-2019-32-denial-of-service-vulnerabilities-in-beckhoff-twincat-plc-environment-fixed/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2019/10/08/r7-2019-32-denial-of-service-vulnerabilities-in-beckhoff-twincat-plc-environment-fixed/"
+            }
+        ]
+    },
+    "source": {
+        "advisory": "R7-2019-32",
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Add vuln descriptions for CVE-2019-5636 and CVE-2019-5637, both in the same versions of Beckhoff Twincat.