### PR TITLE
Rejecting unused CVEs in our block

### DIFF
--- a/2019/5xxx/CVE-2019-5650.json
+++ b/2019/5xxx/CVE-2019-5650.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5650",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5650",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5651.json
+++ b/2019/5xxx/CVE-2019-5651.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5651",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5651",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5652.json
+++ b/2019/5xxx/CVE-2019-5652.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5652",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5652",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5653.json
+++ b/2019/5xxx/CVE-2019-5653.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5653",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5653",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5654.json
+++ b/2019/5xxx/CVE-2019-5654.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5654",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5654",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5655.json
+++ b/2019/5xxx/CVE-2019-5655.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5655",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5655",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5656.json
+++ b/2019/5xxx/CVE-2019-5656.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5656",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5656",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5657.json
+++ b/2019/5xxx/CVE-2019-5657.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5657",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-13368",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5658.json
+++ b/2019/5xxx/CVE-2019-5658.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5658",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5658",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5659.json
+++ b/2019/5xxx/CVE-2019-5659.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5659",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-13368",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5660.json
+++ b/2019/5xxx/CVE-2019-5660.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5660",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5660",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5661.json
+++ b/2019/5xxx/CVE-2019-5661.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5661",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5661",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5662.json
+++ b/2019/5xxx/CVE-2019-5662.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5662",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5662",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5663.json
+++ b/2019/5xxx/CVE-2019-5663.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5663",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5663",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }

--- a/2019/5xxx/CVE-2019-5664.json
+++ b/2019/5xxx/CVE-2019-5664.json
@@ -1,17 +1,17 @@
 {
-    "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
-        "ID": "CVE-2019-5664",
-        "STATE": "RESERVED"
-    },
-    "data_format": "MITRE",
     "data_type": "CVE",
+    "data_format": "MITRE",
     "data_version": "4.0",
+    "CVE_data_meta": {
+        "ID": "CVE-2019-5664",
+        "ASSIGNER": "cve@mitre.org",
+        "STATE": "REJECT"
+    },
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: This candidate was withdrawn by its CNA. Further investigation showed that it was not a security issue. Notes: none."
             }
         ]
     }


### PR DESCRIPTION
This replaces all our unused, unreserved CVEs with the standard MITRE text.