### PR TITLE
Populate CVE-2020-7351

### DIFF
--- a/2020/7xxx/CVE-2020-7351.json
+++ b/2020/7xxx/CVE-2020-7351.json
@@ -60,11 +60,7 @@
     "description_data": [
       {
         "lang": "eng",
-        "value": "An OS Command Injection vulnerability in the endpoint_devicemap.php component of Fonality Trixbox Community Edition allows an attacker to execute commands on the underlying operating system as the \"asterisk\" user. Note that Trixbox Community Edition has been unsupported by the vendor since 2012."
-      },
-      {
-        "lang": "eng",
-        "value": "This issue affects:\nFonality Trixbox Community Edition\n2.8.0.4 version 2.8.0.4 and prior versions."
+        "value": "An OS Command Injection vulnerability in the endpoint_devicemap.php component of Fonality Trixbox Community Edition allows an attacker to execute commands on the underlying operating system as the \"asterisk\" user. Note that Trixbox Community Edition has been unsupported by the vendor since 2012.\n\nThis issue affects:\nFonality Trixbox Community Edition\nversion 2.8.0.4 and prior versions."
       }
     ]
   },

--- a/2020/7xxx/CVE-2020-7351.json
+++ b/2020/7xxx/CVE-2020-7351.json
@@ -34,6 +34,18 @@
                       "version_affected": "<=",
                       "version_value": "2.8.0.4",
                       "platform": ""
+                    },
+                    {
+                      "version_name": "1.0",
+                      "version_affected": "!",
+                      "version_value": "1.0",
+                      "platform": ""
+                    },
+                    {
+                      "version_name": "1.1",
+                      "version_affected": "!",
+                      "version_value": "1.1",
+                      "platform": ""
                     }
                   ]
                 }
@@ -60,7 +72,7 @@
     "description_data": [
       {
         "lang": "eng",
-        "value": "An OS Command Injection vulnerability in the endpoint_devicemap.php component of Fonality Trixbox Community Edition allows an attacker to execute commands on the underlying operating system as the \"asterisk\" user. Note that Trixbox Community Edition has been unsupported by the vendor since 2012.\n\nThis issue affects:\nFonality Trixbox Community Edition\nversion 2.8.0.4 and prior versions."
+        "value": "An OS Command Injection vulnerability in the endpoint_devicemap.php component of Fonality Trixbox Community Edition allows an attacker to execute commands on the underlying operating system as the \"asterisk\" user. Note that Trixbox Community Edition has been unsupported by the vendor since 2012.\n\nThis issue affects:\nFonality Trixbox Community Edition, versions 1.2.0 through 2.8.0.4. Versions 1.0 and 1.1 are unaffected."
       }
     ]
   },

--- a/2020/7xxx/CVE-2020-7351.json
+++ b/2020/7xxx/CVE-2020-7351.json
@@ -1,18 +1,111 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2020-7351",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Vulnogram 0.0.9"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2020-7351",
+    "ASSIGNER": "cve@rapid7.com",
+    "DATE_PUBLIC": "2020-04-28T14:27:00.000Z",
+    "TITLE": "Fonality Trixbox CE Post-Authentication Command Injection",
+    "AKA": "",
+    "STATE": "PUBLIC"
+  },
+  "source": {
+    "defect": [],
+    "advisory": "",
+    "discovery": "EXTERNAL"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Fonality",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "Trixbox Community Edition",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "2.8.0.4",
+                      "version_affected": "<=",
+                      "version_value": "2.8.0.4",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-78 OS Command Injection"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "An OS Command Injection vulnerability in the endpoint_devicemap.php component of Fonality Trixbox Community Edition allows an attacker to execute commands on the underlying operating system as the \"asterisk\" user. Note that Trixbox Community Edition has been unsupported by the vendor since 2012."
+      },
+      {
+        "lang": "eng",
+        "value": "This issue affects:\nFonality Trixbox Community Edition\n2.8.0.4 version 2.8.0.4 and prior versions."
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "MISC",
+        "url": "https://github.com/rapid7/metasploit-framework/pull/13353",
+        "name": "https://github.com/rapid7/metasploit-framework/pull/13353"
+      }
+    ]
+  },
+  "configuration": [],
+  "impact": {
+    "cvss": {
+      "version": "3.1",
+      "attackVector": "NETWORK",
+      "attackComplexity": "LOW",
+      "privilegesRequired": "LOW",
+      "userInteraction": "REQUIRED",
+      "scope": "UNCHANGED",
+      "confidentialityImpact": "HIGH",
+      "integrityImpact": "HIGH",
+      "availabilityImpact": "NONE",
+      "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N",
+      "baseScore": 7.3,
+      "baseSeverity": "HIGH"
+    }
+  },
+  "exploit": [
+    {
+      "lang": "eng",
+      "value": "An exploit is available at https://github.com/rapid7/metasploit-framework/pull/13353"
+    }
+  ],
+  "work_around": [],
+  "solution": [],
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "This issue was discovered and reported by Anastasios Stasinopoulos."
+    }
+  ]
 }


### PR DESCRIPTION
This adds a CVE for Trixbox CE, from a Metasploit contributor.

See https://github.com/rapid7/metasploit-framework/pull/13353