### PR TITLE
Add CVE-2020-7354 and CVE-2020-7355 for Metasploit

### DIFF
--- a/2020/7xxx/CVE-2020-7354.json
+++ b/2020/7xxx/CVE-2020-7354.json
@@ -44,7 +44,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Cross-site Scripting (XSS) vulnerability in the 'host' field of a discovered scan asset in Rapid7 Metasploit Pro allows an attacker with a specially-crafted network service of a scan target store an XSS sequence in the Metasploit Pro console, which will trigger when the operator views the record of that scanned host in the Metasploit Pro interface. This issue affects Rapid7 Metasploit Pro version 4.17.1-20200427 and prior versions, and is fixed in Metasploit Pro version 4.17.1-20200514.\n\nSee also CVE-2020-7354, which describes a similar issue, but involving the generated 'notes' field of a discovered scan asset."
+                "value": "Cross-site Scripting (XSS) vulnerability in the 'host' field of a discovered scan asset in Rapid7 Metasploit Pro allows an attacker with a specially-crafted network service of a scan target store an XSS sequence in the Metasploit Pro console, which will trigger when the operator views the record of that scanned host in the Metasploit Pro interface. This issue affects Rapid7 Metasploit Pro version 4.17.1-20200427 and prior versions, and is fixed in Metasploit Pro version 4.17.1-20200514.\n\nSee also CVE-2020-7355, which describes a similar issue, but involving the generated 'notes' field of a discovered scan asset."
             }
         ]
     },

--- a/2020/7xxx/CVE-2020-7354.json
+++ b/2020/7xxx/CVE-2020-7354.json
@@ -44,7 +44,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "Cross-site Scripting (XSS) vulnerability in the 'host' field of a discovered scan asset in Rapid7 Metasploit Pro allows an attacker with a specially-crafted network service of a scan target store an XSS sequence in the Metasploit Pro console, which will trigger when the operator views the record of that scanned host in the Metasploit Pro interface. This issue affects Rapid7 Metasploit Pro version 4.17.1-20200427 and prior versions, and is fixed in Metasploit Pro version 4.17.1-20200514.\n\nSee also CVE-2020-7355, which describes a similar issue, but involving the generated 'notes' field of a discovered scan asset."
+                "value": "Cross-site Scripting (XSS) vulnerability in the 'host' field of a discovered scan asset in Rapid7 Metasploit Pro allows an attacker with a specially-crafted network service of a scan target to store an XSS sequence in the Metasploit Pro console, which will trigger when the operator views the record of that scanned host in the Metasploit Pro interface. This issue affects Rapid7 Metasploit Pro version 4.17.1-20200427 and prior versions, and is fixed in Metasploit Pro version 4.17.1-20200514.\n\nSee also CVE-2020-7355, which describes a similar issue, but involving the generated 'notes' field of a discovered scan asset."
             }
         ]
     },

--- a/2020/7xxx/CVE-2020-7354.json
+++ b/2020/7xxx/CVE-2020-7354.json
@@ -1,18 +1,105 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-05-21T13:13:00.000Z",
         "ID": "CVE-2020-7354",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Rapid7 Metasploit Pro Stored XSS in 'host' field"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Metasploit Pro",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "4.17.1-20200427",
+                                            "version_value": "4.17.1-20200427"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Rapid7"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Andrea Valenza at the University of Genoa discovered and reported this issue to Rapid7"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Cross-site Scripting (XSS) vulnerability in the 'host' field of a discovered scan asset in Rapid7 Metasploit Pro allows an attacker with a specially-crafted network service of a scan target store an XSS sequence in the Metasploit Pro console, which will trigger when the operator views the record of that scanned host in the Metasploit Pro interface. This issue affects Rapid7 Metasploit Pro version 4.17.1-20200427 and prior versions, and is fixed in Metasploit Pro version 4.17.1-20200514.\n\nSee also CVE-2020-7354, which describes a similar issue, but involving the generated 'notes' field of a discovered scan asset."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.1,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79 Cross-site Scripting (XSS)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://help.rapid7.com/metasploit/release-notes/archive/2020/05/#20200514",
+                "refsource": "CONFIRM",
+                "url": "https://help.rapid7.com/metasploit/release-notes/archive/2020/05/#20200514"
+            },
+            {
+                "name": "https://avalz.it/research/metasploit-pro-xss-to-rce/",
+                "refsource": "MISC",
+                "url": "https://avalz.it/research/metasploit-pro-xss-to-rce/"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update to Metasploit Pro version 4.17.1-20200514 to fix this issue."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2020/7xxx/CVE-2020-7355.json
+++ b/2020/7xxx/CVE-2020-7355.json
@@ -1,18 +1,105 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-05-21T13:13:00.000Z",
         "ID": "CVE-2020-7355",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Rapid7 Metasploit Pro Stored XSS in 'notes' field"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Metasploit Pro",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "4.17.1-20200427",
+                                            "version_value": "4.17.1-20200427"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Rapid7"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "Andrea Valenza at the University of Genoa discovered and reported this issue to Rapid7"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "Cross-site Scripting (XSS) vulnerability in the 'notes' field of a discovered scan asset in Rapid7 Metasploit Pro allows an attacker with a specially-crafted network service of a scan target store an XSS sequence in the Metasploit Pro console, which will trigger when the operator views the record of that scanned host in the Metasploit Pro interface. This issue affects Rapid7 Metasploit Pro version 4.17.1-20200427 and prior versions, and is fixed in Metasploit Pro version 4.17.1-20200514.\n\nSee also CVE-2020-7354, which describes a similar issue, but involving the generated 'host' field of a discovered scan asset."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 6.1,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "HIGH",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-79 Cross-site Scripting (XSS)"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://help.rapid7.com/metasploit/release-notes/archive/2020/05/#20200514",
+                "refsource": "CONFIRM",
+                "url": "https://help.rapid7.com/metasploit/release-notes/archive/2020/05/#20200514"
+            },
+            {
+                "name": "https://avalz.it/research/metasploit-pro-xss-to-rce/",
+                "refsource": "MISC",
+                "url": "https://avalz.it/research/metasploit-pro-xss-to-rce/"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Update to Metasploit Pro version 4.17.1-20200514 to fix this issue."
+        }
+    ],
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
For the recently fixed Metasploit Pro bugs, discussed in issue 7104 in the security ticket queue.

@djordan-r7, can you take a look for spelling and grammar and sensibility? If you have any question, just hit me up on Slack.