### PR TITLE
Add Philips CVE-2020-7360

### DIFF
--- a/2020/7xxx/CVE-2020-7360.json
+++ b/2020/7xxx/CVE-2020-7360.json
@@ -1,18 +1,99 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-08-06T13:27:00.000Z",
         "ID": "CVE-2020-7360",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Philips SmartControl DLL Hijacking"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "SmartControl",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "=",
+                                            "version_name": "4.3.15",
+                                            "version_value": "4.3.15"
+                                        },
+                                        {
+                                            "version_affected": "!",
+                                            "version_name": "1.0.7",
+                                            "version_value": "1.0.7"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Philips"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered and reported by Erik Wynter of Vonahi Security."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "An Uncontrolled Search Path Element (CWE-427) vulnerability in SmartControl version 4.3.15 and versions released before April 15, 2020 may allow an authenticated user to escalate privileges by placing a specially crafted DLL file in the search path. This issue was fixed in version 1.0.7, which was released after April 15, 2020. (Note, the version numbering system changed significantly between version 4.3.15 and version 1.0.7.)"
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "HIGH",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "LOW",
+            "baseScore": 7.4,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "CHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:L",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-427 Uncontrolled Search Path Element"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://blog.vonahi.io/when-the-path-to-system-is-wide-open/",
+                "refsource": "MISC",
+                "url": "https://blog.vonahi.io/when-the-path-to-system-is-wide-open/"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Here's the new CVE for Philips SmartControl, from Metasploit contributor @kalba-security -- he's reviewed it for accuracy, so if I can get a spellcheck/sanity check, that'd be swell!