### PR TITLE
Add CVEs for two Metasploit modules

### DIFF
--- a/2020/7xxx/CVE-2020-7376.json
+++ b/2020/7xxx/CVE-2020-7376.json
@@ -49,7 +49,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The Metasploit Framework module \"post/osx/gather/enum_osx module\" is affected by a relative path traversal vulnerability in the get_keychains method which can be exploited to write arbitrary files to arbitrary locations on the host filesystem when the module is run on a malicious host. This issue was resolved in version 6.0.3 of the Metasploit Framework, built on August 20, 2020."
+                "value": "The Metasploit Framework module \"post/osx/gather/enum_osx module\" is affected by a relative path traversal vulnerability in the get_keychains method which can be exploited to write arbitrary files to arbitrary locations on the host filesystem when the module is run on a malicious host."
             }
         ]
     },

--- a/2020/7xxx/CVE-2020-7376.json
+++ b/2020/7xxx/CVE-2020-7376.json
@@ -1,18 +1,105 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-08-17T10:00:00.000Z",
         "ID": "CVE-2020-7376",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Rapid7 Metasploit Framework Pelative Path Traversal in enum_osx module"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Metasploit Framework",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "4.11.7",
+                                            "version_value": "4.11.7"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "6.0.2",
+                                            "version_value": "6.0.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Rapid7"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was reported, and fixed, by bcoles."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "The Metasploit Framework module \"post/osx/gather/enum_osx module\" is affected by a relative path traversal vulnerability in the get_keychains method which can be exploited to write arbitrary files to arbitrary locations on the host filesystem when the module is run on a malicious host. This issue was resolved in version 6.0.2 of the Metasploit Framework, built on August 20, 2020."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-23 Relative Path Traversal"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/rapid7/metasploit-framework/issues/14008",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/rapid7/metasploit-framework/issues/14008"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Users should update to version 6.0.2 or later of the Metasploit Framework."
+        }
+    ],
+    "source": {
+        "discovery": "INTERNAL"
     }
 }

--- a/2020/7xxx/CVE-2020-7376.json
+++ b/2020/7xxx/CVE-2020-7376.json
@@ -4,7 +4,7 @@
         "DATE_PUBLIC": "2020-08-17T10:00:00.000Z",
         "ID": "CVE-2020-7376",
         "STATE": "PUBLIC",
-        "TITLE": "Rapid7 Metasploit Framework Pelative Path Traversal in enum_osx module"
+        "TITLE": "Rapid7 Metasploit Framework Relative Path Traversal in enum_osx module"
     },
     "affects": {
         "vendor": {

--- a/2020/7xxx/CVE-2020-7376.json
+++ b/2020/7xxx/CVE-2020-7376.json
@@ -23,8 +23,8 @@
                                         },
                                         {
                                             "version_affected": "<",
-                                            "version_name": "6.0.2",
-                                            "version_value": "6.0.2"
+                                            "version_name": "6.0.3",
+                                            "version_value": "6.0.3"
                                         }
                                     ]
                                 }
@@ -49,7 +49,7 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "The Metasploit Framework module \"post/osx/gather/enum_osx module\" is affected by a relative path traversal vulnerability in the get_keychains method which can be exploited to write arbitrary files to arbitrary locations on the host filesystem when the module is run on a malicious host. This issue was resolved in version 6.0.2 of the Metasploit Framework, built on August 20, 2020."
+                "value": "The Metasploit Framework module \"post/osx/gather/enum_osx module\" is affected by a relative path traversal vulnerability in the get_keychains method which can be exploited to write arbitrary files to arbitrary locations on the host filesystem when the module is run on a malicious host. This issue was resolved in version 6.0.3 of the Metasploit Framework, built on August 20, 2020."
             }
         ]
     },
@@ -96,7 +96,7 @@
     "solution": [
         {
             "lang": "eng",
-            "value": "Users should update to version 6.0.2 or later of the Metasploit Framework."
+            "value": "Users should update to version 6.0.3 or later of the Metasploit Framework."
         }
     ],
     "source": {

--- a/2020/7xxx/CVE-2020-7377.json
+++ b/2020/7xxx/CVE-2020-7377.json
@@ -23,8 +23,8 @@
                                         },
                                         {
                                             "version_affected": "<",
-                                            "version_name": "6.0.2",
-                                            "version_value": "6.0.2"
+                                            "version_name": "6.0.3",
+                                            "version_value": "6.0.3"
                                         }
                                     ]
                                 }
@@ -96,7 +96,7 @@
     "solution": [
         {
             "lang": "eng",
-            "value": "Users should update to version 6.0.2 or later of the Metasploit Framework."
+            "value": "Users should update to version 6.0.3 or later of the Metasploit Framework."
         }
     ],
     "source": {

--- a/2020/7xxx/CVE-2020-7377.json
+++ b/2020/7xxx/CVE-2020-7377.json
@@ -4,7 +4,7 @@
         "DATE_PUBLIC": "2020-08-18T08:48:00.000Z",
         "ID": "CVE-2020-7377",
         "STATE": "PUBLIC",
-        "TITLE": "Rapid7 Metasploit Framework Pelative Path Traversal in telpho10_credential_dump module"
+        "TITLE": "Rapid7 Metasploit Framework Relative Path Traversal in telpho10_credential_dump module"
     },
     "affects": {
         "vendor": {

--- a/2020/7xxx/CVE-2020-7377.json
+++ b/2020/7xxx/CVE-2020-7377.json
@@ -1,18 +1,105 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-08-18T08:48:00.000Z",
         "ID": "CVE-2020-7377",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Rapid7 Metasploit Framework Pelative Path Traversal in telpho10_credential_dump module"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Metasploit Framework",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": ">=",
+                                            "version_name": "4.12.40",
+                                            "version_value": "4.12.40"
+                                        },
+                                        {
+                                            "version_affected": "<",
+                                            "version_name": "6.0.2",
+                                            "version_value": "6.0.2"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Rapid7"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was reported, and fixed, by bcoles."
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "The Metasploit Framework module \"auxiliary/admin/http/telpho10_credential_dump\" module is affected by a relative path traversal vulnerability in the untar method which can be exploited to write arbitrary files to arbitrary locations on the host file system when the module is run on a malicious HTTP server."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 8.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-23 Relative Path Traversal"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/rapid7/metasploit-framework/issues/14015",
+                "refsource": "CONFIRM",
+                "url": "https://github.com/rapid7/metasploit-framework/issues/14015"
+            }
+        ]
+    },
+    "solution": [
+        {
+            "lang": "eng",
+            "value": "Users should update to version 6.0.2 or later of the Metasploit Framework."
+        }
+    ],
+    "source": {
+        "discovery": "INTERNAL"
     }
 }


### PR DESCRIPTION
Covers the issues discussed at rapid7/metasploit-framework#14008 and rapid7/metasploit-framework#14015

@bcoles feel free to take a look and tell me if something is grossly wrong! I always feel like I'm just guessing at CVSS scores, they get rewritten upstream anyway by NVD (nobody believes the issuer of CVEs for CVSS, turns out).