### PR TITLE
Add CVE-2019-5645 for Metasploit

### DIFF
--- a/2019/5xxx/CVE-2019-5645.json
+++ b/2019/5xxx/CVE-2019-5645.json
@@ -1,9 +1,42 @@
 {
     "CVE_data_meta": {
-        "ASSIGNER": "cve@mitre.org",
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2019-10-09T14:54:00.000Z",
         "ID": "CVE-2019-5645",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Rapid7 Metasploit HTTP Handler Denial of Service"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Metasploit Framework",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "5.0.27",
+                                            "version_value": "5.0.27"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Rapid7"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was reported by Jose Garduno of Dreamlab Technologies, AG"
+        }
+    ],
     "data_format": "MITRE",
     "data_type": "CVE",
     "data_version": "4.0",
@@ -11,8 +44,51 @@
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "By sending a specially crafted HTTP GET request to a listening Rapid7 Metasploit HTTP handler, an attacker can register an arbitrary regular expression. When evaluated, this malicious handler can either prevent new HTTP handler sessions from being established, or cause a resource exhaustion on the Metasploit server. "
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-400 Uncontrolled Resource Consumption"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://github.com/rapid7/metasploit-framework/pull/12433",
+                "refsource": "MISC",
+                "url": "https://github.com/rapid7/metasploit-framework/pull/12433"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Releasing this long overdue CVE ID, originally reported by @deepsight. @djordan-r7, take a look?