### PR TITLE
CVEs for slate of address bar spoofing bugs

### DIFF
--- a/2020/7xxx/CVE-2020-7363.json
+++ b/2020/7xxx/CVE-2020-7363.json
@@ -1,18 +1,99 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-10-20T13:00:00.000Z",
         "ID": "CVE-2020-7363",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "UCWeb UC Browser Address Bar Spooofing"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "UC Browser",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "13.0.8",
+                                            "version_value": "13.0.8"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "UCWeb"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered by Rafay Baloch, and disclosed in accordance with Rapid7's coordinated vulnerability disclosure policy at https://www.rapid7.com/security/disclosure#zeroday"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "User Interface (UI) Misrepresentation of Critical Information vulnerability in the address bar of UCWeb's UC Browser allows an attacker to obfuscate the true source of data as presented in the browser. This issue affects UCWeb's UC Browser version 13.0.8 and prior versions."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-451 User Interface (UI) Misrepresentation of Critical Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html",
+                "refsource": "MISC",
+                "url": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html"
+            },
+            {
+                "name": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2020/7xxx/CVE-2020-7364.json
+++ b/2020/7xxx/CVE-2020-7364.json
@@ -1,18 +1,99 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-10-20T13:00:00.000Z",
         "ID": "CVE-2020-7364",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "UCWeb UC Browser Address Bar Spooofing"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "UC Browser",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "13.0.8",
+                                            "version_value": "13.0.8"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "UCWeb"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered by Rafay Baloch, and disclosed in accordance with Rapid7's coordinated vulnerability disclosure policy at https://www.rapid7.com/security/disclosure#zeroday"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "User Interface (UI) Misrepresentation of Critical Information vulnerability in the address bar of UCWeb's UC Browser allows an attacker to obfuscate the true source of data as presented in the browser. This issue affects UCWeb's UC Browser version 13.0.8 and prior versions."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-451 User Interface (UI) Misrepresentation of Critical Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html",
+                "refsource": "MISC",
+                "url": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html"
+            },
+            {
+                "name": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2020/7xxx/CVE-2020-7369.json
+++ b/2020/7xxx/CVE-2020-7369.json
@@ -1,18 +1,99 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-10-20T13:00:00.000Z",
         "ID": "CVE-2020-7369",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC",
+        "TITLE": "Yandex Browser Address Bar Spooofing"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Yandex Browser",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "20.8.3",
+                                            "version_value": "20.8.3"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Yandex"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered by Rafay Baloch, and disclosed in accordance with Rapid7's coordinated vulnerability disclosure policy at https://www.rapid7.com/security/disclosure#zeroday"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "User Interface (UI) Misrepresentation of Critical Information vulnerability in the address bar of the Yandex Browser allows an attacker to obfuscate the true source of data as presented in the browser. This issue affects the Yandex Browser version 20.8.3 and prior versions, and was fixed in version 20.8.4 released October 1, 2020."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-451 User Interface (UI) Misrepresentation of Critical Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html",
+                "refsource": "MISC",
+                "url": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html"
+            },
+            {
+                "name": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2020/7xxx/CVE-2020-7370.json
+++ b/2020/7xxx/CVE-2020-7370.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@rapid7.com",
         "DATE_PUBLIC": "2020-10-20T13:00:00.000Z",
-        "ID": "CVE-2020-7369",
+        "ID": "CVE-2020-7370",
         "STATE": "PUBLIC",
         "TITLE": "Danyil Vasilenko Bolt Browser Address Bar Spooofing"
     },

--- a/2020/7xxx/CVE-2020-7370.json
+++ b/2020/7xxx/CVE-2020-7370.json
@@ -1,18 +1,99 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
-        "ID": "CVE-2020-7370",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-10-20T13:00:00.000Z",
+        "ID": "CVE-2020-7369",
+        "STATE": "PUBLIC",
+        "TITLE": "Danyil Vasilenko Bolt Browser Address Bar Spooofing"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "Bolt Browser",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "1.4",
+                                            "version_value": "1.4"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Danyil Vasilenko"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered by Rafay Baloch, and disclosed in accordance with Rapid7's coordinated vulnerability disclosure policy at https://www.rapid7.com/security/disclosure#zeroday"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "User Interface (UI) Misrepresentation of Critical Information vulnerability in the address bar of Danyil Vasilenko's Bolt Browser allows an attacker to obfuscate the true source of data as presented in the browser. This issue affects the Bolt Browser version 1.4 and prior versions."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-451 User Interface (UI) Misrepresentation of Critical Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html",
+                "refsource": "MISC",
+                "url": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html"
+            },
+            {
+                "name": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }

--- a/2020/7xxx/CVE-2020-7371.json
+++ b/2020/7xxx/CVE-2020-7371.json
@@ -2,7 +2,7 @@
     "CVE_data_meta": {
         "ASSIGNER": "cve@rapid7.com",
         "DATE_PUBLIC": "2020-10-20T13:00:00.000Z",
-        "ID": "CVE-2020-7369",
+        "ID": "CVE-2020-7371",
         "STATE": "PUBLIC",
         "TITLE": "Raise IT Solutions RITS Browser Address Bar Spooofing"
     },

--- a/2020/7xxx/CVE-2020-7371.json
+++ b/2020/7xxx/CVE-2020-7371.json
@@ -1,18 +1,99 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
-        "ID": "CVE-2020-7371",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "ASSIGNER": "cve@rapid7.com",
+        "DATE_PUBLIC": "2020-10-20T13:00:00.000Z",
+        "ID": "CVE-2020-7369",
+        "STATE": "PUBLIC",
+        "TITLE": "Raise IT Solutions RITS Browser Address Bar Spooofing"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "RITS Browser",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_affected": "<=",
+                                            "version_name": "3.3.9",
+                                            "version_value": "3.3.9"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "Raise IT Solutions"
+                }
+            ]
+        }
+    },
+    "credit": [
+        {
+            "lang": "eng",
+            "value": "This issue was discovered by Rafay Baloch, and disclosed in accordance with Rapid7's coordinated vulnerability disclosure policy at https://www.rapid7.com/security/disclosure#zeroday"
+        }
+    ],
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "User Interface (UI) Misrepresentation of Critical Information vulnerability in the address bar of the Yandex Browser allows an attacker to obfuscate the true source of data as presented in the browser. This issue affects the RITS Browser version 3.3.9 and prior versions."
             }
         ]
+    },
+    "generator": {
+        "engine": "Vulnogram 0.0.9"
+    },
+    "impact": {
+        "cvss": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.3,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "REQUIRED",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+        }
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "CWE-451 User Interface (UI) Misrepresentation of Critical Information"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "name": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html",
+                "refsource": "MISC",
+                "url": "https://www.rafaybaloch.com/2020/10/multiple-address-bar-spoofing-vulnerabilities.html"
+            },
+            {
+                "name": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/",
+                "refsource": "MISC",
+                "url": "https://blog.rapid7.com/2020/10/20/vulntober-multiple-mobile-browser-address-bar-spoofing-vulnerabilities/"
+            }
+        ]
+    },
+    "source": {
+        "discovery": "EXTERNAL"
     }
 }


### PR DESCRIPTION
Thanks to @rafaybaloch for discovering and reporting these!

Note, there is a /ton/ of copy paste in here, so please check that I haven't leaked one vuln to the other. With that in mind, the two UC Browser bugs /should/ read identically. Rafay defines them uniquely in his paper as two separately patchable bugs that ultimately have the same effect.