### PR TITLE
Rectify RBP on CVE-2020-7373

### DIFF
--- a/2020/7xxx/CVE-2020-7373.json
+++ b/2020/7xxx/CVE-2020-7373.json
@@ -1,17 +1,76 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
     "CVE_data_meta": {
+        "ASSIGNER": "cve@rapid7.com",
         "ID": "CVE-2020-7373",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
+        "STATE": "PUBLIC"
     },
+    "affects": {
+        "vendor": {
+            "vendor_data": [
+                {
+                    "product": {
+                        "product_data": [
+                            {
+                                "product_name": "n/a",
+                                "version": {
+                                    "version_data": [
+                                        {
+                                            "version_value": "n/a"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "vendor_name": "n/a"
+                }
+            ]
+        }
+    },
+    "data_format": "MITRE",
+    "data_type": "CVE",
+    "data_version": "4.0",
     "description": {
         "description_data": [
             {
                 "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                "value": "vBulletin 5.5.4 through 5.6.2 allows remote command execution via crafted subWidgets data in an ajax/render/widget_tabbedcontainer_tab_panel request. NOTE: this issue exists because of an incomplete fix for CVE-2019-16759. ALSO NOTE: CVE-2020-7373 is a duplicate of CVE-2020-17496. CVE-2020-17496 is the preferred CVE ID to track this vulnerability."
+            }
+        ]
+    },
+    "problemtype": {
+        "problemtype_data": [
+            {
+                "description": [
+                    {
+                        "lang": "eng",
+                        "value": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "references": {
+        "reference_data": [
+            {
+                "url": "https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/",
+                "refsource": "MISC",
+                "name": "https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/"
+            },
+            {
+                "url": "https://forum.vbulletin.com/forum/vbulletin-announcements/vbulletin-announcements_aa/4445227-vbulletin-5-6-0-5-6-1-5-6-2-security-patch",
+                "refsource": "MISC",
+                "name": "https://forum.vbulletin.com/forum/vbulletin-announcements/vbulletin-announcements_aa/4445227-vbulletin-5-6-0-5-6-1-5-6-2-security-patch"
+            },
+            {
+                "url": "https://seclists.org/fulldisclosure/2020/Aug/5",
+                "refsource": "MISC",
+                "name": "https://seclists.org/fulldisclosure/2020/Aug/5"
+            },
+            {
+                "url": "https://github.com/rapid7/metasploit-framework/pull/13970",
+                "refsource": "MISC",
+                "name": "https://github.com/rapid7/metasploit-framework/pull/13970"
             }
         ]
     }


### PR DESCRIPTION
So back in https://github.com/rapid7/metasploit-framework/pull/13970 , there was some confusion as to who was assigning a CVE to this vulnerability. In the end, MITRE won the race, but PacketStorm picked up our original assignment before we could swap it out of Metasploit.

In order to quit having PacketStorm's reference be invalid, I've populated CVE-2020-7373 with info from [CVE-2020-17496](https://nvd.nist.gov/vuln/detail/CVE-2020-17496), as well as a reference to the Metasploit pull request and a note to prefer CVE-2020-17496. Hopefully, this will get us out of RBP purgatory.