### PR TITLE
Add CVE-2022-3218 for Necta WiFi Mouse (Mouse Server)

### DIFF
--- a/2022/3xxx/CVE-2022-3218.json
+++ b/2022/3xxx/CVE-2022-3218.json
@@ -1,18 +1,107 @@
 {
-    "data_type": "CVE",
-    "data_format": "MITRE",
-    "data_version": "4.0",
-    "CVE_data_meta": {
-        "ID": "CVE-2022-3218",
-        "ASSIGNER": "cve@mitre.org",
-        "STATE": "RESERVED"
-    },
-    "description": {
-        "description_data": [
-            {
-                "lang": "eng",
-                "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-            }
-        ]
+  "data_type": "CVE",
+  "data_format": "MITRE",
+  "data_version": "4.0",
+  "generator": {
+    "engine": "Vulnogram 0.0.9"
+  },
+  "CVE_data_meta": {
+    "ID": "CVE-2022-3218",
+    "ASSIGNER": "cve@rapid7.com",
+    "DATE_PUBLIC": "2021-02-25T14:00:00.000Z",
+    "TITLE": "Necta WiFi Mouse (Mouse Server) client-side authentication bypass",
+    "AKA": "",
+    "STATE": "PUBLIC"
+  },
+  "source": {
+    "defect": [],
+    "advisory": "",
+    "discovery": "EXTERNAL"
+  },
+  "affects": {
+    "vendor": {
+      "vendor_data": [
+        {
+          "vendor_name": "Necta LLC",
+          "product": {
+            "product_data": [
+              {
+                "product_name": "WiFi Mouse (Mouse Server)",
+                "version": {
+                  "version_data": [
+                    {
+                      "version_name": "1.8.3.4",
+                      "version_affected": "<=",
+                      "version_value": "1.8.3.4",
+                      "platform": ""
+                    },
+                    {
+                      "version_name": "1.8.2.3",
+                      "version_affected": "<=",
+                      "version_value": "1.8.2.3",
+                      "platform": ""
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
+  },
+  "problemtype": {
+    "problemtype_data": [
+      {
+        "description": [
+          {
+            "lang": "eng",
+            "value": "CWE-603 Use of Client-Side Authentication"
+          }
+        ]
+      }
+    ]
+  },
+  "description": {
+    "description_data": [
+      {
+        "lang": "eng",
+        "value": "Due to a reliance on client-side authentication, the WiFi Mouse (Mouse Server) from Necta LLC's authentication mechanism is trivially bypassed, which can result in remote code execution."
+      }
+    ]
+  },
+  "references": {
+    "reference_data": [
+      {
+        "refsource": "MISC",
+        "url": "https://github.com/rapid7/metasploit-framework/pull/16985",
+        "name": "https://github.com/rapid7/metasploit-framework/pull/16985"
+      },
+      {
+        "refsource": "MISC",
+        "url": "https://www.exploit-db.com/exploits/50972",
+        "name": "https://www.exploit-db.com/exploits/50972"
+      },
+      {
+        "refsource": "MISC",
+        "url": "https://www.exploit-db.com/exploits/49601",
+        "name": "https://www.exploit-db.com/exploits/49601"
+      },
+      {
+        "refsource": "MISC",
+        "url": "https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/wifi%20mouse/wifi-mouse-server-rce.py",
+        "name": "https://github.com/H4rk3nz0/PenTesting/blob/main/Exploits/wifi%20mouse/wifi-mouse-server-rce.py"
+      }
+    ]
+  },
+  "configuration": [],
+  "exploit": [],
+  "work_around": [],
+  "solution": [],
+  "credit": [
+    {
+      "lang": "eng",
+      "value": "H4rk3nz0, REDHATAUGUST, and h00die discovered and reported this vulnerability."
+    }
+  ]
 }


### PR DESCRIPTION
Adds CVE-2022-3218 for Necta WiFi Mouse (Mouse Server).